### PR TITLE
Use graphic masking instead of TMP text truncation

### DIFF
--- a/Packages/com.varneon.vudon.logger/Runtime/Prefabs/UdonConsole.prefab
+++ b/Packages/com.varneon.vudon.logger/Runtime/Prefabs/UdonConsole.prefab
@@ -914,6 +914,7 @@ GameObject:
   - component: {fileID: 3682445367726478583}
   - component: {fileID: 5762018827471488495}
   - component: {fileID: 4877366624895502930}
+  - component: {fileID: 1234110849547823592}
   m_Layer: 0
   m_Name: LOG_ENTRY
   m_TagString: Untagged
@@ -969,7 +970,7 @@ MonoBehaviour:
     m_SelectOnRight: {fileID: 0}
   m_Transition: 1
   m_Colors:
-    m_NormalColor: {r: 0.24705882, g: 0.24705882, b: 0.24705882, a: 0}
+    m_NormalColor: {r: 0.22, g: 0.22, b: 0.22, a: 1}
     m_HighlightedColor: {r: 0.24705882, g: 0.24705882, b: 0.24705882, a: 1}
     m_PressedColor: {r: 0.17254902, g: 0.3647059, b: 0.5294118, a: 1}
     m_SelectedColor: {r: 0.17254902, g: 0.3647059, b: 0.5294118, a: 1}
@@ -1043,6 +1044,19 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1234110849547823592
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3682445367726478538}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1
 --- !u!1 &3682445367852420914
 GameObject:
   m_ObjectHideFlags: 0
@@ -1810,7 +1824,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_enableWordWrapping: 0
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 3
+  m_overflowMode: 2
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1


### PR DESCRIPTION
UdonConsole does not rely on TMP truncation anymore to keep messages on one line, UI Mask is used instead on the selectable log element to mask the rest of the message.

Fixes #26